### PR TITLE
Change the mode of the binaries to 0755

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ None.
 - `group` - the group of the Terraform and terraform-docs binaries.
   Defaults to "root".
 - `mode` - the mode of the Terraform and terraform-docs binaries.
-  Defaults to "0766".
+  Defaults to "0755".
 - `owner` - the owner of the Terraform and terraform-docs binaries.
   Defaults to "root".
 - `terraform_version` - the version of Terraform to install. Defaults

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ install_dir: /usr/local/bin
 # The group of the Terraform and terraform-docs binaries
 group: root
 # The mode of the Terraform and terraform-docs binaries
-mode: 0766
+mode: 0755
 # The owner of the Terraform and terraform-docs binaries
 owner: root
 # The version of Terraform to install

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -22,4 +22,4 @@ def test_expected_files_are_present(host, filename):
     assert f.is_file
     assert f.user == "root"
     assert f.group == "root"
-    assert f.mode == 0o766
+    assert f.mode == 0o755


### PR DESCRIPTION
## 🗣 Description ##

Correct the mode of the binaries being installed from `0766` to `0755`.

## 💭 Motivation and context ##

I assume this was a typo, but either way the mistake is mine.  With `0766` only the owner (`root` by default) can run the executable.

## 🧪 Testing ##

App `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] All new and existing tests pass.
