### PR TITLE
Install the latest versions of `terraform` and `terraform docs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ None.
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| terraform\_docs\_version | The version of terraform-docs to install. | `0.14.1` | No |
+| terraform\_docs\_version | The version of terraform-docs to install. | `0.18.0` | No |
 | terraform\_group | The group associated with the Terraform and terraform-docs binaries. | `root` | No |
 | terraform\_install\_dir | The directory where the Terraform and terraform-docs binaries are to be installed. | `/usr/local/bin` | No |
 | terraform\_mode | The mode of the Terraform and terraform-docs binaries. | `0755` | No |
 | terraform\_owner | The owner of the Terraform and terraform-docs binaries. | `root` | No |
-| terraform\_version | The version of Terraform to install. | `1.0.4` | No |
+| terraform\_version | The version of Terraform to install. | `1.8.5` | No |
 
 ## Dependencies ##
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # The version of terraform-docs to install
-terraform_docs_version: 0.14.1
+terraform_docs_version: 0.18.0
 # The group of the Terraform and terraform-docs binaries
 terraform_group: root
 # The directory where the Terraform and terraform-docs binaries are to
@@ -11,4 +11,4 @@ terraform_mode: 0755
 # The owner of the Terraform and terraform-docs binaries
 terraform_owner: root
 # The version of Terraform to install
-terraform_version: 1.0.4
+terraform_version: 1.8.5

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -23,3 +23,13 @@ def test_expected_files_are_present(host, filename):
     assert f.user == "root"
     assert f.group == "root"
     assert f.mode == 0o755
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["/usr/local/bin/terraform --version", "/usr/local/bin/terraform-docs --version"],
+)
+def test_tools_can_run(host, command):
+    """Verify that the installed tools can run."""
+    cmd = host.run(command)
+    assert cmd.rc == 0, f"Command {command} returned a non-zero exit code."


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Updates the role to install the latest versions of `terraform` and `terraform-docs`
- Adds a test to ensure that `terraform` and `terraform-docs` can actually run

## 💭 Motivation and context ##

- The versions of `terraform` and `terraform-docs` being installed were ancient.
- The new test gives a little more confidence that the tools we are installing can actually be used.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.