### PR TITLE
Use `terraform` 1.5.7 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ None.
 | terraform\_install\_dir | The directory where the Terraform and terraform-docs binaries are to be installed. | `/usr/local/bin` | No |
 | terraform\_mode | The mode of the Terraform and terraform-docs binaries. | `0755` | No |
 | terraform\_owner | The owner of the Terraform and terraform-docs binaries. | `root` | No |
-| terraform\_version | The version of Terraform to install. | `1.8.5` | No |
+| terraform\_version | The version of Terraform to install. | `1.5.7` | No |
 
 ## Dependencies ##
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,4 +11,17 @@ terraform_mode: 0755
 # The owner of the Terraform and terraform-docs binaries
 terraform_owner: root
 # The version of Terraform to install
-terraform_version: 1.8.5
+#
+# We are choosing to remain on v1.5 due to HashiCorp's decision to
+# change the license of Terraform from MPL 2.0 to BSL starting with
+# 1.6.0. This is done for several reasons:
+# - The Business Source License (BSL/BUSL) is not considered an Open
+#   Source license.
+# - We may have issues around compatibility with Terraform 1.6+ if we
+#   leverage non-HashiCorp tooling.
+# - We may decide to switch to OpenTofu in the future and
+#   compatibility is only guaranteed with Terraform 1.5 and below.
+# - The Cloud Native Computing Foundation (CNCF) recommends
+#   considering alternative components if a project uses a component
+#   under the BUSL-1.1 license.
+terraform_version: 1.5.7


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible role to by default install the latest version of `terraform` that was released under an open source license.

## 💭 Motivation and context ##

@mcdonnnj pointed out that [installing the very latest version of `terraform` disagrees with what we are doing elsewhere](https://github.com/cisagov/ansible-role-terraform/pull/30#issuecomment-2156224911).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.