### PR TITLE
Install correct architecture for `terraform` and `terraform-docs`

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -4,3 +4,12 @@
 
 - name: Import externally-managed-python playbook
   ansible.builtin.import_playbook: externally-managed-python.yml
+
+# This package is needed for one of our Molecule tests.
+- name: Install file system package
+  hosts: all
+  tasks:
+    - name: Install file
+      ansible.builtin.package:
+        name:
+          - file

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -30,6 +30,11 @@ def test_expected_files_are_present(host, filename):
     ["/usr/local/bin/terraform --version", "/usr/local/bin/terraform-docs --version"],
 )
 def test_tools_can_run(host, command):
-    """Verify that the installed tools can run."""
+    """Verify that the installed tools can run.
+
+    Note that this test can still pass when running under qemu if the
+    executable architecture does not match the container but does match
+    the host.
+    """
     cmd = host.run(command)
     assert cmd.rc == 0, f"Command {command} returned a non-zero exit code."

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -38,7 +38,7 @@ def test_tools_executable_architecture(host, executable):
     # file prints out the architecture as "x86-64" or "aarch64".  The call to
     # string.replace() is therefore necessary to match up these two
     # conventions.
-    assert host.system_info.arch.replace("_", "-") in cmd.stdout
+    assert host.system_info.arch.replace("x86_64", "x86-64") in cmd.stdout
 
 
 @pytest.mark.parametrize(

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -26,6 +26,22 @@ def test_expected_files_are_present(host, filename):
 
 
 @pytest.mark.parametrize(
+    "executable",
+    ["/usr/local/bin/terraform", "/usr/local/bin/terraform-docs"],
+)
+def test_tools_executable_architecture(host, executable):
+    """Verify that the installed tools have the appropriate architecture."""
+    command = f"file {executable}"
+    cmd = host.run(command)
+    assert cmd.rc == 0, f"Command {command} returned a non-zero exit code."
+    # host.system_info.arch will return either "x86_64" or "aarch64", whereas
+    # file prints out the architecture as "x86-64" or "aarch64".  The call to
+    # string.replace() is therefore necessary to match up these two
+    # conventions.
+    assert host.system_info.arch.replace("_", "-") in cmd.stdout
+
+
+@pytest.mark.parametrize(
     "command",
     ["/usr/local/bin/terraform --version", "/usr/local/bin/terraform-docs --version"],
 )

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: Load var file based on the OS type
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_distribution }}_{{ ansible_distribution_release }}.yml"
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+        - default.yml
+      paths:
+        - "{{ role_path }}/vars"
+
 # This is necessary in order to unarchive the Terraform zip and the
 # terraform-docs tarball.
 - name: Install tar and unzip
@@ -15,7 +27,7 @@
     mode: "{{ terraform_mode }}"
     owner: "{{ terraform_owner }}"
     remote_src: true
-    src: https://releases.hashicorp.com/terraform/{{ terraform_version }}/terraform_{{ terraform_version }}_linux_amd64.zip
+    src: "{{ terraform_url }}"
 
 - name: Download and install terraform-docs binary
   ansible.builtin.unarchive:
@@ -28,4 +40,4 @@
     mode: "{{ terraform_mode }}"
     owner: "{{ terraform_owner }}"
     remote_src: true
-    src: https://github.com/terraform-docs/terraform-docs/releases/download/v{{ terraform_docs_version }}/terraform-docs-v{{ terraform_docs_version }}-linux-amd64.tar.gz
+    src: "{{ terraform_docs_url }}"

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,0 +1,10 @@
+# A dictionary whose keys are values of the Ansible fact
+# ansible_architecture and whose values are processor architecture for
+# which terraform and terraform-docs are to be installed, as specified in the URL to
+architectures:
+  aarch64: arm64
+  x86_64: amd64
+
+terraform_docs_url: https://github.com/terraform-docs/terraform-docs/releases/download/v{{ terraform_docs_version }}/terraform-docs-v{{ terraform_docs_version }}-linux-{{ architectures[ansible_architecture] }}.tar.gz
+
+terraform_url: https://releases.hashicorp.com/terraform/{{ terraform_version }}/terraform_{{ terraform_version }}_linux_{{ architectures[ansible_architecture] }}.zip


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes a bug where the Ansible role was installing AMD64 executables on ARM64 systems.

## 💭 Motivation and context ##

ARM64 systems can't natively run AMD64 executables.

## 🧪 Testing ##

All automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.